### PR TITLE
[MISC] Update create-feature-branch logic

### DIFF
--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -34,7 +34,7 @@ jobs:
             BASE_VERSION=$(echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
 
             # Check if corresponding full release exists
-            if git ls-remote --tags origin | grep -q "refs/tags/$BASE_VERSION$"; then
+            if git ls-remote --tags https://${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git | grep -q "refs/tags/$BASE_VERSION$"; then
               echo "::notice::Skipping pre-release tag $TAG because full release $BASE_VERSION exists"
               echo "is_prerelease=true" >> $GITHUB_OUTPUT
               echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -15,7 +15,7 @@ jobs:
   check-tag:
     runs-on: ubuntu-latest
     outputs:
-      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      skip_feature_branch_creation: ${{ steps.check.outputs.skip_feature_branch_creation }}
       tag: ${{ steps.check.outputs.tag }}
       branch_name: ${{ steps.check.outputs.branch_name }}
     steps:
@@ -28,33 +28,33 @@ jobs:
             TAG="${GITHUB_REF#refs/tags/}"
           fi
 
-          # Check if this is a pre-release tag
-          if [[ "$TAG" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
-            # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
-            BASE_VERSION=$(echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
+          # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+          BASE_VERSION=$(echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
 
-            # Check if corresponding full release exists
+          # Check if this is a pre-release tag by comparing with base version
+          if [[ "$TAG" != "$BASE_VERSION" ]]; then
+            # This is a pre-release tag, check if corresponding full release exists
             if git ls-remote --tags https://${{ secrets.ORG_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git | grep -q "refs/tags/$BASE_VERSION$"; then
               echo "::notice::Skipping pre-release tag $TAG because full release $BASE_VERSION exists"
-              echo "is_prerelease=true" >> $GITHUB_OUTPUT
+              echo "skip_feature_branch_creation=true" >> $GITHUB_OUTPUT
               echo "tag=$TAG" >> $GITHUB_OUTPUT
               echo "branch_name=" >> $GITHUB_OUTPUT
             else
               echo "::notice::Processing pre-release tag $TAG (no full release $BASE_VERSION found)"
-              echo "is_prerelease=false" >> $GITHUB_OUTPUT
+              echo "skip_feature_branch_creation=false" >> $GITHUB_OUTPUT
               echo "tag=$TAG" >> $GITHUB_OUTPUT
               echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
             fi
           else
             echo "::notice::Processing stable release tag: $TAG"
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "skip_feature_branch_creation=false" >> $GITHUB_OUTPUT
             echo "tag=$TAG" >> $GITHUB_OUTPUT
             echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
           fi
 
   create-feature-branch:
     needs: check-tag
-    if: needs.check-tag.outputs.is_prerelease == 'false'
+    if: needs.check-tag.outputs.skip_feature_branch_creation == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -96,12 +96,12 @@ jobs:
 
           for tag in $ALL_TAGS; do
             if [[ "$FOUND_CURRENT" == "true" ]]; then
-              # Check if this is a pre-release tag
-              if [[ "$tag" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
-                # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
-                BASE_VERSION=$(echo "$tag" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
+              # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+              BASE_VERSION=$(bash scripts/extract_base_version.sh "$tag")
 
-                # Check if corresponding full release exists
+              # Check if this is a pre-release tag by comparing with base version
+              if [[ "$tag" != "$BASE_VERSION" ]]; then
+                # This is a pre-release tag, check if corresponding full release exists
                 if git ls-remote --tags origin | grep -q "refs/tags/$BASE_VERSION$"; then
                   echo "Skipping pre-release tag $tag because full release $BASE_VERSION exists"
                   continue

--- a/.github/workflows/create-feature-branches.yml
+++ b/.github/workflows/create-feature-branches.yml
@@ -12,7 +12,49 @@ on:
         type: string
 
 jobs:
+  check-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      tag: ${{ steps.check.outputs.tag }}
+      branch_name: ${{ steps.check.outputs.branch_name }}
+    steps:
+      - name: Check if tag should be processed
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+
+          # Check if this is a pre-release tag
+          if [[ "$TAG" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
+            # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+            BASE_VERSION=$(echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
+
+            # Check if corresponding full release exists
+            if git ls-remote --tags origin | grep -q "refs/tags/$BASE_VERSION$"; then
+              echo "::notice::Skipping pre-release tag $TAG because full release $BASE_VERSION exists"
+              echo "is_prerelease=true" >> $GITHUB_OUTPUT
+              echo "tag=$TAG" >> $GITHUB_OUTPUT
+              echo "branch_name=" >> $GITHUB_OUTPUT
+            else
+              echo "::notice::Processing pre-release tag $TAG (no full release $BASE_VERSION found)"
+              echo "is_prerelease=false" >> $GITHUB_OUTPUT
+              echo "tag=$TAG" >> $GITHUB_OUTPUT
+              echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "::notice::Processing stable release tag: $TAG"
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+          fi
+
   create-feature-branch:
+    needs: check-tag
+    if: needs.check-tag.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,16 +72,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Get tag name
+      - name: Set tag variables
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "branch_name=features-based-on-$TAG" >> $GITHUB_OUTPUT
+          echo "tag=${{ needs.check-tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo "branch_name=${{ needs.check-tag.outputs.branch_name }}" >> $GITHUB_OUTPUT
 
       - name: Find previous tag with existing branch
         id: previous_tag
@@ -59,6 +96,20 @@ jobs:
 
           for tag in $ALL_TAGS; do
             if [[ "$FOUND_CURRENT" == "true" ]]; then
+              # Check if this is a pre-release tag
+              if [[ "$tag" =~ [\.-]?(rc|alpha|beta|pre|dev)[0-9]*$ ]]; then
+                # Extract base version (e.g., v0.10.0 from v0.10.0rc1)
+                BASE_VERSION=$(echo "$tag" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//')
+
+                # Check if corresponding full release exists
+                if git ls-remote --tags origin | grep -q "refs/tags/$BASE_VERSION$"; then
+                  echo "Skipping pre-release tag $tag because full release $BASE_VERSION exists"
+                  continue
+                else
+                  echo "Considering pre-release tag $tag (no full release $BASE_VERSION found)"
+                fi
+              fi
+
               # This is a previous tag, check if it has a feature branch
               CANDIDATE_BRANCH="features-based-on-$tag"
               echo "Checking if branch exists for tag $tag: $CANDIDATE_BRANCH"

--- a/scripts/extract_base_version.sh
+++ b/scripts/extract_base_version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Extract base version from a tag by removing pre-release suffixes
+# Example: v0.10.0rc1 -> v0.10.0
+# Example: v1.2.3-alpha2 -> v1.2.3
+# Example: v2.0.0.dev5 -> v2.0.0
+#
+# Usage: extract_base_version.sh <tag>
+#   tag: The version tag to process (e.g., v0.10.0rc1)
+#
+# Returns: The base version without pre-release suffix
+
+if [ -z "$1" ]; then
+  echo "Error: No tag provided" >&2
+  echo "Usage: $0 <tag>" >&2
+  exit 1
+fi
+
+TAG="$1"
+
+# Remove pre-release suffixes (rc, alpha, beta, pre, dev followed by optional numbers)
+# Matches: -rc1, .rc1, rc1, -alpha, .beta2, dev5, etc.
+echo "$TAG" | sed -E 's/[\.-]?(rc|alpha|beta|pre|dev)[0-9]*$//'


### PR DESCRIPTION
## Motivation
We want to refine the logic for creating feature branches to skip pre-release tags, but sometimes when moving fast with new features or bugfixes pre-release tags are necessary. The updated logic skips pre-release tags if there's already a full release tag on that version (v0.10.0rc is skipped if v0.10.0 is already out) but creates a feature branch for pre-releases without a corresponding full release out.

## Changes
 - Update logic to create feature branches for pre-releases only if there isn't a corresponding full release of that version

## Testing
Example run where pre-release is skipped can be seen here: https://github.com/TJ5/sglang/actions/runs/18178291803/job/51748944929

Example run where pre-release is not skipped is here: https://github.com/TJ5/sglang/actions/runs/18178941359/job/51750784079