### PR TITLE
 [MISC] [Redo] Update create-feature-branch logic 

### DIFF
--- a/scripts/extract_base_version.sh
+++ b/scripts/extract_base_version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Extract base version from a tag by removing pre-release suffixes
 # Example: v0.10.0rc1 -> v0.10.0
 # Example: v1.2.3-alpha2 -> v1.2.3


### PR DESCRIPTION
Copying from: https://github.com/moirai-internal/sglang/pull/31
## Motivation
We want to refine the logic for creating feature branches to skip pre-release tags, but sometimes when moving fast with new features or bugfixes pre-release tags are necessary. The updated logic skips pre-release tags if there's already a full release tag on that version (v0.10.0rc is skipped if v0.10.0 is already out) but creates a feature branch for pre-releases without a corresponding full release out.

## Changes
 - Update logic to create feature branches for pre-releases only if there isn't a corresponding full release of that version

## Testing
Example run where pre-release is skipped can be seen here: https://github.com/TJ5/sglang/actions/runs/18178291803/job/51748944929

Example run where pre-release is not skipped is here: https://github.com/TJ5/sglang/actions/runs/18178941359/job/51750784079